### PR TITLE
Use less restric rules for autoActivation

### DIFF
--- a/src/main/java/org/scijava/plugins/scripteditor/jython/JythonAutocompletionProvider.java
+++ b/src/main/java/org/scijava/plugins/scripteditor/jython/JythonAutocompletionProvider.java
@@ -57,6 +57,7 @@ public class JythonAutocompletionProvider extends DefaultCompletionProvider {
 		this.text_area = text_area;
 		this.formatter = formatter;
 		this.setParameterizedCompletionParams('(', ", ", ')'); // for methods and functions
+		setAutoActivationRules(true, "."); // when using auto-activation, make it so that it occurs after any letter or '.'
 		new Thread(ClassUtil::ensureCache).start();
 	}
 	


### PR DESCRIPTION
@acardona, when auto-activation is enabled in the  TextEditor, this should make so that the auto-completion popup appears mid-word after the default 300ms delay.

This addresses what was discussed in https://github.com/scijava/script-editor/pull/56#issuecomment-1050968182