### PR TITLE
Update script-editor dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,8 +113,7 @@
 		<antlr-runtime.version>3.5.2</antlr-runtime.version>
 
 		<!-- TEMP: Until pom-scijava 32.0.0 is released and used here. -->
-		<script-editor.version>0.7.1-SNAPSHOT</script-editor.version>
-		<enforcer.skip>true</enforcer.skip> <!-- ONLY while depending on a SNAPSHOT -->
+		<script-editor.version>0.7.1</script-editor.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
Now that the script editor v0.7.1 has been released (i.e., it is listed at https://maven.scijava.org/)
we no longer need to rely on SNAPSHOT versions and we no longer need to disable the enforcer
This should allow a proper release